### PR TITLE
Implement custom file locator strategies

### DIFF
--- a/src/org/tiledreader/DefaultFileLocatorStrategy.java
+++ b/src/org/tiledreader/DefaultFileLocatorStrategy.java
@@ -1,0 +1,27 @@
+package org.tiledreader;
+
+import java.io.*;
+
+public class DefaultFileLocatorStrategy implements FileLocatorStrategy {
+    @Override
+    public InputStream openPath(String path) {
+        try {
+            return new FileInputStream(getCanonicalFile(path));
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String resolvePath(String path, String basePath) {
+        return getCanonicalFile(new File(basePath).toPath().resolveSibling(path).toString()).getPath();
+    }
+
+    private static File getCanonicalFile(String path) {
+        try {
+            return new File(path).getCanonicalFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/org/tiledreader/DefaultFileLocatorStrategy.java
+++ b/src/org/tiledreader/DefaultFileLocatorStrategy.java
@@ -3,6 +3,16 @@ package org.tiledreader;
 import java.io.*;
 
 public class DefaultFileLocatorStrategy implements FileLocatorStrategy {
+
+    @Override
+    public String sanitizePath(String path) {
+        try {
+            return new File(path).getCanonicalPath();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public InputStream openPath(String path) {
         try {

--- a/src/org/tiledreader/FileLocatorStrategy.java
+++ b/src/org/tiledreader/FileLocatorStrategy.java
@@ -1,0 +1,8 @@
+package org.tiledreader;
+
+import java.io.InputStream;
+
+public interface FileLocatorStrategy {
+    InputStream openPath(String path);
+    String resolvePath(String path, String basePath);
+}

--- a/src/org/tiledreader/FileLocatorStrategy.java
+++ b/src/org/tiledreader/FileLocatorStrategy.java
@@ -3,6 +3,21 @@ package org.tiledreader;
 import java.io.InputStream;
 
 public interface FileLocatorStrategy {
+
+    /**
+     * Opens an InputStream to the given path
+     *
+     * @param path
+     * @return
+     */
     InputStream openPath(String path);
+
+    /**
+     * Resolves a relative path
+     *
+     * @param path
+     * @param basePath
+     * @return
+     */
     String resolvePath(String path, String basePath);
 }

--- a/src/org/tiledreader/FileLocatorStrategy.java
+++ b/src/org/tiledreader/FileLocatorStrategy.java
@@ -5,6 +5,14 @@ import java.io.InputStream;
 public interface FileLocatorStrategy {
 
     /**
+     * Map all paths pointing to the same file to a single path representation. (e.g. relative paths to absolute path).
+     *
+     * @param path
+     * @return
+     */
+    String sanitizePath(String path);
+
+    /**
      * Opens an InputStream to the given path
      *
      * @param path

--- a/src/org/tiledreader/TiledReader.java
+++ b/src/org/tiledreader/TiledReader.java
@@ -396,7 +396,7 @@ public final class TiledReader {
             throw new RuntimeException("Attempted to read a Tiled map from a path that does not point to a"
                     + " TMX file: " + path);
         }
-
+        path = fileLocator.sanitizePath(path);
         ResourceData data = resources.get(path);
         if (data == null) {
             data = new ResourceData();
@@ -456,6 +456,7 @@ public final class TiledReader {
             throw new RuntimeException("Attempted to read a Tiled tileset from a path that does not point to"
                     + " a TSX file: " + path);
         }
+        path = fileLocator.sanitizePath(path);
         ResourceData data = resources.get(path);
         if (data == null) {
             data = new ResourceData();

--- a/src/org/tiledreader/TiledReader.java
+++ b/src/org/tiledreader/TiledReader.java
@@ -364,7 +364,7 @@ public final class TiledReader {
         LOGGER.setLevel(Level.INFO);
     }
 
-    public static FileLocatorStrategy fileLocator;
+    public static FileLocatorStrategy fileLocator = new DefaultFileLocatorStrategy();
 
     private static final Base64.Decoder BASE_64_DECODER = Base64.getDecoder();
     


### PR DESCRIPTION
This PR implements a mechanism to supply custom strategies to locate and open files. In order to achieve this, `TiledReader` is changed to only use `String` paths, not `File`s. All path resolving and actually loading is done via a `FileLocatorStrategy` interface. A `DefaultFileLocatorStrategy`, which does the same as before, is the default.

The reasoning behind this is that some game engines supply their own logic to locate assets. In my case this is the [jMonkeyEngine](https://github.com/jMonkeyEngine/jmonkeyengine) with it's `AssetManager`, which handles locating and loading all assets.
With this PR one can easily implement adapters to custom asset loading logic.